### PR TITLE
Add homebrew formulae install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ cd ttf-aporetic
 makepkg -si
 ```
 
+### Install with Homebrew
+
+Use the following command:
+
+```sh
+brew install font-aporetic
+```
+
 ## Build information
 
 _Aporetic_ is configured in accordance with the documentation of the upstream project. This practically means that (i) [we clone the official repo](https://github.com/be5invis/iosevka), (ii) define our `private-build-plans.toml` at its root, (iii) install the `npm` dependencies, and (iv) build the `.ttf` files with something like the following for each variant (run from the root of the project):


### PR DESCRIPTION
This is now available via [homebrew formulae](https://github.com/Homebrew/homebrew-cask/pull/202192) making this easily available via homebrew users.

Note, along with the font-aporetic formulae being added, the formulae used for font-iosevka-comfy has been marked as deprecated with font-aporetica marked as replacement.